### PR TITLE
Correção de conflito com outros módulos de pagamento

### DIFF
--- a/Model/Webservice/ConfigProvider.php
+++ b/Model/Webservice/ConfigProvider.php
@@ -70,22 +70,28 @@ class ConfigProvider extends CcGenericConfigProvider
      */
     public function getConfig()
     {
-        $config = parent::getConfig();
+        $method = $this->_webserviceHelper->getMethodCode();
 
-        if ($this->_webserviceHelper->getConfigData('active')) {
-            $config['payment'][$this->_webserviceHelper->getMethodCode()] = [
-                'active'               => true,
-                'icons'                => $this->_getIcons(),
-                'installments'         => $this->_installmentsHelper->getInstallments($this->_getPaymentAmount()),
-                'interestRates'        => $this->_installmentsHelper->getInstallmentConfig()
-            ];
-        } else {
-            $config['payment'][$this->_webserviceHelper->getMethodCode()] = [
-                'active'                                  => false,
+        if (!$this->_webserviceHelper->getConfigData('active')) {
+            return [
+                'payment' => [
+                    $method => [
+                        'active' => false,
+                    ]
+                ]
             ];
         }
 
-        return $config;
+        return [
+            'payment' => [
+                $method => [
+                    'active'        => true,
+                    'icons'         => $this->_getIcons(),
+                    'installments'  => $this->_installmentsHelper->getInstallments($this->_getPaymentAmount()),
+                    'interestRates' => $this->_installmentsHelper->getInstallmentConfig()
+                ]
+            ]
+        ];
     }
 
     /**


### PR DESCRIPTION
Nesta alteração foi corrigido um conflito deste módulo com outros módulos de pagamento, estou usando o mercado pago como exemplo, pois neste módulo ele chamava o getConfig do parent, assim causando duplicação dos meses/ano da data de validade do cartão de crédito, após essa correção, este erro parou de acontecer em todos os módulos de pagamento que eu utilizo na loja.

Evidência:
![meses repetidos](https://user-images.githubusercontent.com/2152861/29477871-a8c5eff8-8440-11e7-8875-f448f24f1625.png)
